### PR TITLE
chore: update invite link to vanity invite

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -2,7 +2,7 @@ blank_issues_enabled: true
 contact_links:
   - name: Discord server
     about: Use our official Discord server to ask for help.
-    url: https://discord.gg/gJDbCw8aQy
+    url: https://discord.gg/disnake
   - name: disnake issues
     about: Issue tracker for the disnake library.
     url: https://github.com/DisnakeDev/disnake/issues/new/choose

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Disnake Guide (WIP)
 
 <p align="center">
-    <a href="https://discord.gg/gJDbCw8aQy"><img src="https://img.shields.io/discord/808030843078836254?style=flat-square&color=5865f2&logo=discord&logoColor=ffffff&label=discord" alt="Discord server invite" /></a>
+    <a href="https://discord.gg/disnake"><img src="https://img.shields.io/discord/808030843078836254?style=flat-square&color=5865f2&logo=discord&logoColor=ffffff&label=discord" alt="Discord server invite" /></a>
     <a href="https://github.com/DisnakeDev/disnake/commits"><img src="https://img.shields.io/github/commit-activity/w/DisnakeDev/guide.svg?style=flat-square" alt="Commit activity" /></a>
     <a href="https://guide.disnake.dev/"><img src="https://img.shields.io/github/deployments/DisnakeDev/guide/github-pages?style=flat-square&color=blue" alt="GitHub checks" /></a>
 </p>
@@ -37,8 +37,8 @@ For more info on development/contributions, see [CONTRIBUTING.md](./.github/CONT
     ⁕
     <a href="https://guide.disnake.dev/">Guide</a>
     ⁕
-    <a href="https://discord.gg/gJDbCw8aQy">Discord Server</a>
+    <a href="https://discord.gg/disnake">Discord Server</a>
     ⁕
-    <a href="https://discord.gg/discord-api">Discord API</a>
+    <a href="https://discord.gg/discord-developers">Discord Developers</a>
 </p>
 <br />

--- a/guide/docs/faq/intro.mdx
+++ b/guide/docs/faq/intro.mdx
@@ -8,7 +8,7 @@ keywords: [disnake, bot, guide, tutorial, python, faq]
 # Frequently Asked Questions
 
 This is a list of Frequently Asked Questions regarding using `disnake` and its extension modules. Feel free to suggest a
-new at the [support server](https://discord.gg/gJDbCw8aQy), or submit one via pull requests on [the repository](https://github.com/DisnakeDev/guide/pulls).
+new at the [support server](https://discord.gg/disnake), or submit one via pull requests on [the repository](https://github.com/DisnakeDev/guide/pulls).
 
 ## Legend
 


### PR DESCRIPTION
## Description

<!--
Describe what this change is, and why it was made.
-->
Discord recently verified our server, so without concern of losing our vanity, we are now safe to update all invites to https://discord.gg/disnake


