### PR TITLE
fix(content): use `edit_original_response` instead of `edit_original_message`

### DIFF
--- a/guide/docs/interactions/slash-commands.mdx
+++ b/guide/docs/interactions/slash-commands.mdx
@@ -162,7 +162,7 @@ An interaction can only be responded to **once**. After a response is made, **no
 If you're going to run long processes (more than 3 seconds) before responding, you should first <DocsLink reference="disnake.InteractionResponse.defer">defer</DocsLink> the interaction,
 as interactions expire after 3 seconds and later responses will fail.
 Deferring an interaction response shows a loading indicator to the user, and gives you more time to prepare a complete response.
-Once your response is ready, you can edit the original response using the <DocsLink reference="disnake.Interaction.edit_original_message">Interaction.edit_original_message</DocsLink> method.
+Once your response is ready, you can edit the original response using the <DocsLink reference="disnake.Interaction.edit_original_response">Interaction.edit_original_response</DocsLink> method.
 
 :::
 
@@ -176,7 +176,7 @@ async def ping(inter: ApplicationCommandInteraction):
 async def defer(inter: ApplicationCommandInteraction):
     await inter.response.defer()
     await asyncio.sleep(10)
-    await inter.edit_original_message(content="The wait is over, my comrades!")
+    await inter.edit_original_response(content="The wait is over, my comrades!")
 ```
 
 ### Followups


### PR DESCRIPTION
## Description

See https://github.com/DisnakeDev/disnake/pull/738.
Depends on #46, also shouldn't be merged before 2.6 is released, hence the draft status.