### PR TITLE
fix(content): link to stable docs instead of latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The concept we will be going over, include:
 -   How to get started on working with bots;
 -   How to create and organize commands, using cogs/extensions;
 -   Working with databases (such as [`sqlite`][sqlite-docs] and [`mongodb (motor)`][motor-docs]);
--   Using the [`AutoShardedClient`](https://disnake.readthedocs.io/en/latest/api.html#disnake.AutoShardedClient) class
+-   Using the [`AutoShardedClient`](https://disnake.readthedocs.io/en/stable/api.html#disnake.AutoShardedClient) class
     to shard your bot;
 -   A plethora of examples with popular topics along with in-depth explanation, and much more!
 

--- a/guide/docs/faq/coroutines.mdx
+++ b/guide/docs/faq/coroutines.mdx
@@ -9,7 +9,7 @@ Questions regarding coroutines and asyncio belong here.
 
 :::note
 
-This content has been taken directly from the [documentation](https://docs.disnake.dev/en/latest/faq.html), and inherited from `discord.py`. It will most likely be rewritten in the future.
+This content has been taken directly from the [documentation](https://docs.disnake.dev/en/stable/faq.html), and inherited from `discord.py`. It will most likely be rewritten in the future.
 
 :::
 
@@ -27,7 +27,7 @@ You can only use `await` inside `async def` functions and nowhere else.
 
 In asynchronous programming a blocking call is essentially all the parts of the function that are not `await`. Do not despair however, because not all forms of blocking are bad! Using blocking calls is inevitable, but you must work to make sure that you don't excessively block functions. Remember, if you block for too long then your bot will freeze since it has not stopped the function's execution at that point to do other things.
 
-If logging is enabled, this library will attempt to warn you that blocking is occurring with the message: `Heartbeat blocked for more than N seconds.` See [Setting Up Logging](https://docs.disnake.dev/en/latest/logging.html#logging-setup) for details on enabling logging.
+If logging is enabled, this library will attempt to warn you that blocking is occurring with the message: `Heartbeat blocked for more than N seconds.` See [Setting Up Logging](https://docs.disnake.dev/en/stable/logging.html#logging-setup) for details on enabling logging.
 
 A common source of blocking for too long is something like [`time.sleep`](https://docs.python.org/3/library/time.html#time.sleep). Don't do that. Use [`asyncio.sleep`](https://docs.python.org/3/library/asyncio-task.html#asyncio.sleep)
 instead. Similar to this example:

--- a/guide/docs/faq/extensions.mdx
+++ b/guide/docs/faq/extensions.mdx
@@ -9,7 +9,7 @@ Questions regarding `disnake.ext.commands`, `disnake.ext.tasks` and `disnake.ui`
 
 :::note
 
-This content has been taken directly from the [documentation](https://docs.disnake.dev/en/latest/faq.html), and inherited from `discord.py`. It will most likely be rewritten in the future.
+This content has been taken directly from the [documentation](https://docs.disnake.dev/en/stable/faq.html), and inherited from `discord.py`. It will most likely be rewritten in the future.
 
 :::
 

--- a/guide/docs/faq/general.mdx
+++ b/guide/docs/faq/general.mdx
@@ -9,7 +9,7 @@ General questions regarding library usage belong here.
 
 :::note
 
-This content has been taken directly from the [documentation](https://docs.disnake.dev/en/latest/faq.html), and inherited from `discord.py`. It will most likely be rewritten in the future.
+This content has been taken directly from the [documentation](https://docs.disnake.dev/en/stable/faq.html), and inherited from `discord.py`. It will most likely be rewritten in the future.
 
 :::
 

--- a/guide/docs/getting-started/using-cogs.mdx
+++ b/guide/docs/getting-started/using-cogs.mdx
@@ -5,14 +5,14 @@ keywords: [disnake, bot, guide, tutorial, cogs, extensions, python]
 
 # Creating cogs/extensions
 
-[**Cogs**](https://docs.disnake.dev/en/latest/ext/commands/cogs.html) are analogous to modules that extend the core of
+[**Cogs**](https://docs.disnake.dev/en/stable/ext/commands/cogs.html) are analogous to modules that extend the core of
 the bot - thus adding to its functions and abilities. They also allow you to break down and organize your bot's
 collection of commands/listeners (which is useful when your bot's command list becomes quite extensive).
 
 :::note
 
 Cogs are typically used alongside with **Extensions**. You can read more about them
-[in the documentation](https://docs.disnake.dev/en/latest/ext/commands/extensions.html).
+[in the documentation](https://docs.disnake.dev/en/stable/ext/commands/extensions.html).
 
 :::
 
@@ -148,7 +148,7 @@ syntax for loading an extension is `bot.load_extension("<folder_name>.<file_name
 
 And that concludes the use of cogs with `disnake`! You can now create multiple cogs to group and organize your
 commands/events, and load/unload them via your main file. More information on special cog methods and meta options can
-be found [in the documentation](https://docs.disnake.dev/en/latest/ext/commands/cogs.html).
+be found [in the documentation](https://docs.disnake.dev/en/stable/ext/commands/cogs.html).
 
 ## Syntax changes
 
@@ -165,7 +165,7 @@ the primary syntax used in cogs:
 -   Cogs are then registered with the <DocsLink ext="commands" reference="disnake.ext.commands.Bot.add_cog">Bot.add_cog</DocsLink> call, and are subsequently removed with the <DocsLink ext="commands" reference="disnake.ext.commands.Bot.remove_cog">Bot.remove_cog</DocsLink> call.
 
 <sup>
-	Source: <a href="https://docs.disnake.dev/en/latest/ext/commands/cogs.html">Disnake Documentation</a>
+	Source: <a href="https://docs.disnake.dev/en/stable/ext/commands/cogs.html">Disnake Documentation</a>
 </sup>
 
 Cogs represent a fairly drastic change in the way you write commands and bots. Thus, it is recommended that you get

--- a/guide/docs/intro.mdx
+++ b/guide/docs/intro.mdx
@@ -15,7 +15,7 @@ The concept we will be going over, include:
 -   How to get started on working with bots;
 -   How to create and organize commands, using cogs/extensions;
 -   Working with databases (such as [`sqlite (aiosqlite)`][sqlite-docs] and [`mongodb (motor)`][motor-docs]);
--   Using the [`AutoShardedClient`](https://disnake.readthedocs.io/en/latest/api.html#disnake.AutoShardedClient) class
+-   Using the [`AutoShardedClient`](https://disnake.readthedocs.io/en/stable/api.html#disnake.AutoShardedClient) class
     to shard your bot;
 -   A plethora of examples with popular topics along with in-depth explanation, and much more!
 

--- a/guide/docs/popular-topics/errors.mdx
+++ b/guide/docs/popular-topics/errors.mdx
@@ -2,7 +2,7 @@
 
 :::note
 
-This content has been taken directly from the [documentation](https://docs.disnake.dev/en/latest/ext/commands/commands.html#error-handling), and inherited from `discord.py`. It will most likely be rewritten in the future.
+This content has been taken directly from the [documentation](https://docs.disnake.dev/en/stable/ext/commands/commands.html#error-handling), and inherited from `discord.py`. It will most likely be rewritten in the future.
 
 :::
 

--- a/guide/docs/popular-topics/intents.mdx
+++ b/guide/docs/popular-topics/intents.mdx
@@ -7,7 +7,7 @@ keywords: [disnake, bot, guide, tutorial, python, gateway intents]
 
 :::note
 
-This content has been taken directly from the [documentation](https://docs.disnake.dev/en/latest/intents.html), and inherited from `discord.py`. It will most likely be rewritten in the future.
+This content has been taken directly from the [documentation](https://docs.disnake.dev/en/stable/intents.html), and inherited from `discord.py`. It will most likely be rewritten in the future.
 
 :::
 

--- a/guide/docs/popular-topics/threads.mdx
+++ b/guide/docs/popular-topics/threads.mdx
@@ -117,7 +117,7 @@ be `public_thread`, `private_thread` or `news_thread`.
 ## Thread-related events
 
 Threads introduce some new gateway events, which are listed below. You can find more information on these
-[in the documentation](https://docs.disnake.dev/en/latest/api.html#disnake.on_thread_join).
+[in the documentation](https://docs.disnake.dev/en/stable/api.html#disnake.on_thread_join).
 
 -   <DocsLink reference="disnake.on_thread_join">on_thread_join</DocsLink>
 

--- a/guide/docs/prerequisites/creating-your-application.mdx
+++ b/guide/docs/prerequisites/creating-your-application.mdx
@@ -6,7 +6,7 @@ keywords: [disnake, bot, guide, tutorial, create, application, python]
 # Creating your application
 
 The steps mentioned further in this markdown are essentially a copy of the steps
-[mentioned in the documentation](https://docs.disnake.dev/en/latest/discord.html). Therefore, you can follow the steps
+[mentioned in the documentation](https://docs.disnake.dev/en/stable/discord.html). Therefore, you can follow the steps
 from either resource.
 
 :::note

--- a/guide/docusaurus.config.js
+++ b/guide/docusaurus.config.js
@@ -71,7 +71,7 @@ module.exports = {
 					position: 'left',
 				},
 				{
-					to: 'https://docs.disnake.dev/en/latest/api.html',
+					to: 'https://docs.disnake.dev/en/stable/api.html',
 					label: 'API Reference',
 					position: 'left',
 				},

--- a/guide/src/components/DocsLink.jsx
+++ b/guide/src/components/DocsLink.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export default function DocsLink(props) {
-	const basePath = 'https://docs.disnake.dev/en/latest'
+	const basePath = 'https://docs.disnake.dev/en/stable'
 	const docsPath = basePath + (props.ext ? `/ext/${props.ext}` : '') + (props.ext === 'tasks' ? '/index.html' : '/api.html') + (props.reference ? `#${props.reference}` : '')
 	const docsText = (props.children ? props.children : (props.ext ? props.reference.replace(`disnake.ext.${props.ext}.`, "") : props.reference.replace("disnake.", "")))
 


### PR DESCRIPTION
## Description

includes an unprecedented amount of stability, that even nintendo would [e](https://media.discordapp.net/attachments/911287567914238103/1019248566746759188/unknown.png)nvy

I suppose this is somewhat of a proposal, there may be reasons to continue linking to the latest docs in some(?) places, but linking to latest currently results in at least one broken `<DocsLink/>`.