### PR TITLE
Improve the example on "How do i send a message to a specific channel" FAQ paragraph

### DIFF
--- a/guide/docs/faq/general.mdx
+++ b/guide/docs/faq/general.mdx
@@ -53,9 +53,9 @@ bot = commands.Bot(..., activity=activity)
 You must get or fetch the channel directly and then call the appropriate method. Example:
 
 ```python
-channel = bot.get_channel(12324234183172) or await bot.fetch_channel(12324234183172)
-# if Bot.get_channel returns None because the channel is not in the Bot's cache then it'll 
+# If Bot.get_channel returns None because the channel is not in the Bot's cache, 
 # make an API call to fetch the channel
+channel = bot.get_channel(12324234183172) or await bot.fetch_channel(12324234183172)
 
 await channel.send("hello")
 ```

--- a/guide/docs/faq/general.mdx
+++ b/guide/docs/faq/general.mdx
@@ -50,13 +50,10 @@ bot = commands.Bot(..., activity=activity)
 
 ### How do I send a message to a specific channel?
 
-You must get or fetch the channel directly and then call the appropriate method. Example:
+You must fetch the channel directly and then call the appropriate method. Example:
 
 ```python
-channel = bot.get_channel(12324234183172) or await bot.fetch_channel(12324234183172)
-# if Bot.get_channel returns None because the channel is not in the Bot's cache then it'll 
-# make an API call to fetch the channel
-
+channel = bot.get_channel(12324234183172)
 await channel.send("hello")
 ```
 

--- a/guide/docs/faq/general.mdx
+++ b/guide/docs/faq/general.mdx
@@ -50,10 +50,13 @@ bot = commands.Bot(..., activity=activity)
 
 ### How do I send a message to a specific channel?
 
-You must fetch the channel directly and then call the appropriate method. Example:
+You must get or fetch the channel directly and then call the appropriate method. Example:
 
 ```python
-channel = bot.get_channel(12324234183172)
+channel = bot.get_channel(12324234183172) or await bot.fetch_channel(12324234183172)
+# if Bot.get_channel returns None because the channel is not in the Bot's cache then it'll 
+# make an API call to fetch the channel
+
 await channel.send("hello")
 ```
 


### PR DESCRIPTION
## Description

Previously the term "fetch" was used even if the called function obtained the channel object from the bot's cache, to make the example more correct, I added "get or fetch" as term and I've implemented a logic for which if the channel cannot be obtained from the bot's cache it'll be fetched with an API call.

<!--
Describe what this change is, and why it was made.
-->

## Relevant Issues
- **Closes** GH-50
<!--
We highly recommend linking to an issue that has been approved by a maintainer, or making one yourself before opening a PR.

This is important, as a topic that is not approved by a maintainer may not be added.

Link the issue by typing: "Closes #<number>" (e.g. "Closes #0" to close issue 0).
-->
