### PR TITLE
fix: don't specify a `custom_id` for `ui.Modal`

### DIFF
--- a/code-samples/interactions/modals/create-tag.py
+++ b/code-samples/interactions/modals/create-tag.py
@@ -24,11 +24,7 @@ class MyModal(disnake.ui.Modal):
                 style=TextInputStyle.paragraph,
             ),
         ]
-        super().__init__(
-            title="Create Tag",
-            custom_id="create_tag",
-            components=components,
-        )
+        super().__init__(title="Create Tag", components=components)
 
     # The callback received when the user input is completed.
     async def callback(self, inter: disnake.ModalInteraction):

--- a/guide/docs/interactions/modals.mdx
+++ b/guide/docs/interactions/modals.mdx
@@ -65,11 +65,7 @@ class MyModal(disnake.ui.Modal):
                 style=TextInputStyle.paragraph,
             ),
         ]
-        super().__init__(
-            title="Create Tag",
-            custom_id="create_tag",
-            components=components,
-        )
+        super().__init__(title="Create Tag", components=components)
 
     # The callback received when the user input is completed.
     async def callback(self, inter: disnake.ModalInteraction):


### PR DESCRIPTION
## Description

Using `custom_id` with `ui.Modal` (not low-level modals) should be discouraged, since the modal store is only keyed by `(user_id, custom_id)`, which can quickly result in weird issues/race conditions.
The randomly generated ID is pretty much always what you'd want here.

## Relevant Issues

See (1.) here: https://github.com/DisnakeDev/disnake/pull/914
